### PR TITLE
Changed z buffer size in donut.py

### DIFF
--- a/Donuts/donut.py
+++ b/Donuts/donut.py
@@ -17,7 +17,7 @@ def main():
 
     os.system(clear)
     while True:
-        z = [0 for _ in range(4*height*width)]
+        z = [0 for _ in range(height*width)]
         screen = [' ' for _ in range(height*width)]
 
         j=0


### PR DESCRIPTION
Changed z buffer size from `4*height*width` to `height*width` in donut.py.
In the original c code the `memset` function is used to create buffers.  There we have to manually give size of the buffer. Since `memset` work in bytes and int is usually 4 bytes we give the size as `4*height*width`. And for screen buffer we give size as `height*width` because char is one byte. 
But for Python it is not necessary since we are creating the buffer as list and Python can allocate the size based on the datatype of objects in the list.